### PR TITLE
Add bank check for crypto purchases

### DIFF
--- a/server/crypto.lua
+++ b/server/crypto.lua
@@ -76,7 +76,8 @@ RegisterNetEvent('qb-phone:server:PurchaseCrypto', function(type, amount)
 
     local txt = "Purchased " .. amount .. "x " .. v.abbrev
 
-    if Player.Functions.RemoveMoney('bank', cashAmount, txt) then
+    if Player.Functions.GetMoney('bank') >= cashAmount then
+        Player.Functions.RemoveMoney('bank', cashAmount, txt)
         TriggerClientEvent('qb-phone:client:CustomNotification', src,
             "WALLET",
             "You Purchased "..amount.." "..type.."!",

--- a/server/crypto.lua
+++ b/server/crypto.lua
@@ -76,7 +76,7 @@ RegisterNetEvent('qb-phone:server:PurchaseCrypto', function(type, amount)
 
     local txt = "Purchased " .. amount .. "x " .. v.abbrev
 
-    if Player.Functions.GetMoney('bank') >= cashAmount then
+    if Player.PlayerData.money.bank >= cashAmount then
         Player.Functions.RemoveMoney('bank', cashAmount, txt)
         TriggerClientEvent('qb-phone:client:CustomNotification', src,
             "WALLET",


### PR DESCRIPTION
This commit allows players to purchase crypto without going negative(getting crypto for free).

This is needed as some server would want their players banks to go negative in other ways compared to locking it in the core, without being able to buy crypto with money they don't have