### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -27,9 +27,6 @@ files {
     'html/js/*.js',
     'html/img/*.png',
     'html/css/*.css',
-    'html/fonts/*.ttf',
-    'html/fonts/*.otf',
-    'html/fonts/*.woff',
     'html/img/backgrounds/*.png',
     'html/img/apps/*.png',
 }


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.