### PR TITLE
fix: invoice loading

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -144,9 +144,9 @@ local function LoadPhone()
                 PhoneData.Invoices[#PhoneData.Invoices+1] = {
                     id = v.id,
                     citizenid = QBCore.Functions.GetPlayerData().citizenid,
-                    sender = v.name,
-                    society = v.job,
-                    sendercitizenid = v.senderCID,
+                    sender = v.sender,
+                    society = v.society,
+                    sendercitizenid = v.sendercitizenid,
                     amount = v.amount
                 }
             end


### PR DESCRIPTION
This fixes the invoice loading correctly. As the PhoneData table is filled with the phone_invoices table. Which have no mention of the fields used before:

DROP TABLE IF EXISTS `phone_invoices`;
CREATE TABLE IF NOT EXISTS `phone_invoices` (
  `id` int(10) NOT NULL AUTO_INCREMENT,
  `citizenid` varchar(50) DEFAULT NULL,
  `amount` int(11) NOT NULL DEFAULT 0,
  `society` tinytext DEFAULT NULL,
  `sender` varchar(50) DEFAULT NULL,
  `sendercitizenid` varchar(50) DEFAULT NULL,
  `time` int(11) DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `citizenid` (`citizenid`)
) ENGINE=InnoDB AUTO_INCREMENT=42 DEFAULT CHARSET=utf8;