### PR TITLE
Fix: Phone Documents

### DIFF
--- a/server/documents.lua
+++ b/server/documents.lua
@@ -129,6 +129,7 @@ RegisterNetEvent('qb-phone:server:documents_Save_Note_As', function(data, Receiv
         end
     end
 
+    Wait(250)
     local Notes = exports.oxmysql:executeSync('SELECT * FROM phone_note WHERE citizenid = ?', {CID})
     Wait(100)
     TriggerClientEvent('qb-phone:RefReshNotes_Free_Documents', src, Notes)


### PR DESCRIPTION
Added `Wait(250)` before phone_note query to ensure it is in the DB before the query.